### PR TITLE
support windows path separator

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ packages:
 - '.'
 extra-deps: 
 - optparse-declarative-0.3.0
+- filepath-1.4.1.0
 flags: {}
 extra-package-dbs: []
 

--- a/ttask.cabal
+++ b/ttask.cabal
@@ -35,6 +35,7 @@ library
                      , extra
                      , safe
                      , directory
+                     , filepath
   default-language:    Haskell2010
 
 executable ttask


### PR DESCRIPTION
Windows形式のパス区切り文字('\')に対応しました。
